### PR TITLE
sort suggestions by name ascending

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -227,9 +227,8 @@ fn update_suggestions(
             state.suggestions.push((mtch, name.to_string()));
         }
     }
-    // sort the suggestion by match scores
-    state.suggestions.sort_unstable();
-    state.suggestions.reverse();
+    // sort the suggestion by match scores (descending) and name (ascending)
+    state.suggestions.sort_unstable_by(|a, b| b.0.cmp(&a.0).then(a.1.cmp(&b.1)));
 
     for (i, suggestion) in state.suggestions.iter().enumerate() {
         let name = &suggestion.1;


### PR DESCRIPTION
I have a few sets of commands on my $PATH with a common prefix, for example there's a few different aliases for GVim:

```
gvim
gvimdiff
gvimtutor
...
```

although I really only ever want `gvim`. Similarly, I have some kind of nautilus helper program on my $PATH called `nautilus-autorun-software` whereas I only ever want to invoke `nautilus`.

Right now, when I type `gvim` or `nautilus` into rlaunch, it presents me with the longest command first (`gvimtutor` or `nautilus-autorun-software` in the above examples). I think it makes more sense to always show the shortest matching command.

This pull requests adjusts the sorting so that equal scoring matches are presented in ascending name order, which keeps the shortest ones first. So for example it will now give:

    gvim gvimdiff gvimtutor ...

instead of:

    gvimtutor gvimdiff gvim ...